### PR TITLE
Fix default HTTP port value

### DIFF
--- a/eda-modbus-bridge/config.json
+++ b/eda-modbus-bridge/config.json
@@ -36,7 +36,7 @@
     "http": {
       "enabled": false,
       "listen_address": "0.0.0.0",
-      "listen_port": 9090
+      "listen_port": 8080
     }
   },
   "schema": {


### PR DESCRIPTION
8080 inside the container, exposed by default as 9090 (since 8080 is very common)