### PR TITLE
Use Nodesource binary distribution instead

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,5 +19,5 @@ jobs:
         uses: home-assistant/builder@master
         with:
           args: |
-            --all \
+            --amd64 --aarch64 --armv7 \
             --target eda-modbus-bridge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        architecture: [armhf, armv7, amd64, aarch64, i386]
+        architecture: [amd64, aarch64, armv7]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This repository contains the following add-ons
 ![Supports amd64 Architecture][amd64-shield]
 ![Supports armhf Architecture][armhf-shield]
 ![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 A Modbus MQTT bridge for Enervent ventilation units with EDA automation
 
@@ -22,4 +21,3 @@ A Modbus MQTT bridge for Enervent ventilation units with EDA automation
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/eda-modbus-bridge/Dockerfile
+++ b/eda-modbus-bridge/Dockerfile
@@ -5,8 +5,10 @@ ENV LANG=C.UTF-8
 
 WORKDIR /app
 
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+
 RUN apt-get -y update && \
-    apt-get -y install --no-install-recommends git-core nodejs npm gcc g++ make && \
+    apt-get -y install --no-install-recommends git-core nodejs gcc g++ make && \
     rm -rf /var/lib/apt/lists/*
 
 RUN git clone --depth=1 --branch 3.0.1 https://github.com/Jalle19/eda-modbus-bridge.git eda-modbus-bridge

--- a/eda-modbus-bridge/README.md
+++ b/eda-modbus-bridge/README.md
@@ -4,7 +4,6 @@
 ![Supports amd64 Architecture][amd64-shield]
 ![Supports armhf Architecture][armhf-shield]
 ![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 A Home Assistant add-on for the [eda-modbus-bridge](https://github.com/Jalle19/eda-modbus-bridge) application (a 
 Modbus MQTT bridge for Enervent ventilation units with EDA automation)
@@ -17,4 +16,3 @@ For more information about the software itself, see the [eda-modbus-bridge READM
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/eda-modbus-bridge/build.yaml
+++ b/eda-modbus-bridge/build.yaml
@@ -5,4 +5,3 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
   armhf: ghcr.io/home-assistant/armhf-base-debian:bookworm
   armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm
-  i386: ghcr.io/home-assistant/i386-base-debian:bookworm

--- a/eda-modbus-bridge/config.json
+++ b/eda-modbus-bridge/config.json
@@ -7,8 +7,7 @@
     "armhf",
     "armv7",
     "aarch64",
-    "amd64",
-    "i386"
+    "amd64"
   ],
   "init": false,
   "url": "https://github.com/Jalle19/eda-modbus-bridge",


### PR DESCRIPTION
The Debian nodejs and npm packages pull in hundreds of tiny packages which take forever to install.

The downside to this is that we need to drop i386 support, but in 2025 that should be pretty okay.