### PR TITLE
Remove legacy --unhandled-rejections=warn behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@ This repository contains the following add-ons
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
 ![Supports armv7 Architecture][armv7-shield]
 
 A Modbus MQTT bridge for Enervent ventilation units with EDA automation
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg

--- a/eda-modbus-bridge/DOCS.md
+++ b/eda-modbus-bridge/DOCS.md
@@ -32,6 +32,9 @@ http:
   listen_port: 8080
 ```
 
+Make sure you enable the addon watchdog, otherwise you won't be able to automatically recover from transient Modbus 
+errors!
+
 ## Usage
 
 Nominal add-on startup output looks like this:

--- a/eda-modbus-bridge/config.json
+++ b/eda-modbus-bridge/config.json
@@ -4,7 +4,6 @@
   "slug": "eda-modbus-bridge",
   "description": "A Modbus MQTT bridge for Enervent ventilation units with EDA automation",
   "arch": [
-    "armhf",
     "armv7",
     "aarch64",
     "amd64"

--- a/eda-modbus-bridge/entrypoint.sh
+++ b/eda-modbus-bridge/entrypoint.sh
@@ -4,4 +4,4 @@ source config.sh
 
 get-config
 
-node --unhandled-rejections=warn /app/eda-modbus-bridge/dist/eda-modbus-bridge.js ${CMD_OPTIONS}
+node /app/eda-modbus-bridge/dist/eda-modbus-bridge.js ${CMD_OPTIONS}


### PR DESCRIPTION
This is unwanted, we want to fail hard and have the addon watchdog restart us, especially after https://github.com/Jalle19/eda-modbus-bridge/pull/151