### PR TITLE
Bump eda-modbus-bridge to 3.0.2, addon version to 2.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,5 +19,5 @@ jobs:
         uses: home-assistant/builder@master
         with:
           args: |
-            --amd64 --aarch64 --armv7 \
+            --amd64 --aarch64 \
             --target eda-modbus-bridge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        architecture: [amd64, aarch64, armv7]
+        architecture: [amd64, aarch64]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@ This repository contains the following add-ons
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armv7 Architecture][armv7-shield]
 
 A Modbus MQTT bridge for Enervent ventilation units with EDA automation
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg

--- a/eda-modbus-bridge/CHANGELOG.md
+++ b/eda-modbus-bridge/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 2.1.0
+- Drop support for the `armv7` architecture
+- Update [eda-modbus-bridge 3.0.2](https://github.com/Jalle19/eda-modbus-bridge/releases/tag/3.0.2)
+  * Introduce a new error handler that gracefully handles Modbus read/write errors but also terminates the application
+    if too many errors occur subsequently
+  * Updated Systemd service file which reads command-line arguments from a dedicated file
+
 ## 2.0.1
 - Update to [eda-modbus-bridge 3.0.1](https://github.com/Jalle19/eda-modbus-bridge/releases/tag/3.0.1)
   * Don't catch `PortNotOpenError` errors, fixes issue introduced in 3.0.0 where the program was left in a state it

--- a/eda-modbus-bridge/Dockerfile
+++ b/eda-modbus-bridge/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get -y update && \
     apt-get -y install --no-install-recommends git-core nodejs gcc g++ make && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth=1 --branch 3.0.1 https://github.com/Jalle19/eda-modbus-bridge.git eda-modbus-bridge
+RUN git clone --depth=1 --branch 3.0.2 https://github.com/Jalle19/eda-modbus-bridge.git eda-modbus-bridge
 RUN cd eda-modbus-bridge && \
     npm install && \
     npm run build

--- a/eda-modbus-bridge/README.md
+++ b/eda-modbus-bridge/README.md
@@ -13,4 +13,3 @@ For more information about the software itself, see the [eda-modbus-bridge READM
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg

--- a/eda-modbus-bridge/build.yaml
+++ b/eda-modbus-bridge/build.yaml
@@ -3,4 +3,3 @@
 build_from:
   aarch64: ghcr.io/home-assistant/aarch64-base-debian:bookworm
   amd64: ghcr.io/home-assistant/amd64-base-debian:bookworm
-  armv7: ghcr.io/home-assistant/armv7-base-debian:bookworm

--- a/eda-modbus-bridge/config.json
+++ b/eda-modbus-bridge/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Enervent EDA Modbus Bridge",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "slug": "eda-modbus-bridge",
   "description": "A Modbus MQTT bridge for Enervent ventilation units with EDA automation",
   "arch": [

--- a/eda-modbus-bridge/config.json
+++ b/eda-modbus-bridge/config.json
@@ -4,7 +4,6 @@
   "slug": "eda-modbus-bridge",
   "description": "A Modbus MQTT bridge for Enervent ventilation units with EDA automation",
   "arch": [
-    "armv7",
     "aarch64",
     "amd64"
   ],


### PR DESCRIPTION
Making an intermediate release so that there's a version of the addon that has 3.0.2 too.